### PR TITLE
fix php warning on creating new command

### DIFF
--- a/modules/telegram/cmd_edit.inc.php
+++ b/modules/telegram/cmd_edit.inc.php
@@ -103,7 +103,7 @@ if ($res[0]) {
 outHash($rec, $out);
 
 function updateAccess($cmd_id, $users_id) {
-    SQLSelect("DELETE from tlg_user_cmd where CMD_ID=".$cmd_id);
+    SQLExec("DELETE from tlg_user_cmd where CMD_ID=".$cmd_id);
     $users = explode(",", $users_id);
     foreach ( $users as $value ) {
         $recCU=array();


### PR DESCRIPTION
SQLSelect не подходит для выполнение команд модификации тк не корректно обрабатывает их результат, что в частности приводит к warning 
Warning: mysqli_fetch_array() expects parameter 1 to be mysqli_result, boolean given in /var/www/html/lib/mysqli.class.php on line 206