### PR TITLE
При вызове функций из класса class TelegramBot - дает ошибку

### DIFF
--- a/modules/telegram/telegram.class.php
+++ b/modules/telegram/telegram.class.php
@@ -19,7 +19,7 @@ class telegram extends module {
      *
      * @access private
      */
-    private $telegramBot;
+    public $telegramBot;
     private $last_update_id=0;
      
     function __construct() {


### PR DESCRIPTION
Вот пример вызова функции
include_once(DIR_MODULES . 'telegram/telegram.class.php');
$telegram = new telegram();
$me = $telegram->telegramBot->getMe();
DebMes($me);