### PR TITLE
Update Telegram.php

### DIFF
--- a/modules/telegram/Telegram.php
+++ b/modules/telegram/Telegram.php
@@ -2926,7 +2926,7 @@ class TelegramBot
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-        if ($post) {
+        if ($post && count($content)) {
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $content);
         }


### PR DESCRIPTION
Проверка не пустой ли массив $content в функции sendAPIRequest, т.к., после $url = $url.'?chat_id='.$content['chat_id']; unset($content['chat_id']); в некоторых функциях, к примеру, в getChat, массив $content остается пустой и на некоторых системах запрос не отрабатывает.