### PR TITLE
Подготовка к php8

### DIFF
--- a/modules/telegram/telegram.class.php
+++ b/modules/telegram/telegram.class.php
@@ -492,7 +492,7 @@ class telegram extends module {
             {
                 if ($overwrite)
                 {
-                    $data{'ID'} = $rec['ID'];
+                    $data['ID'] = $rec['ID'];
                     SQLUpdate($table, $data); // update
                 }
                 else


### PR DESCRIPTION
С php8 в массивах разрешены только квадратные скобки